### PR TITLE
feat: implement email verification dialog for mobile and tablet

### DIFF
--- a/lib/core/constants/app_texts.dart
+++ b/lib/core/constants/app_texts.dart
@@ -1,3 +1,12 @@
 class AppTexts {
   static String letsGetToKnowYouTitle = "Lets Get to know you";
+
+  // Verification Dialog Texts
+  static const String verificationTitle = "Enter Verification code";
+  static const String verificationTitleMobile = "Enter\nVerification code";
+  static const String verificationInstruction = "Enter the 6-digit code sent to ";
+  static const String verificationValidity = ". This code is valid for 5 minutes.";
+  static const String verifyButton = "Verify";
+  static const String resendText = "Didn't receive a code? ";
+  static const String resendButton = "Resend";
 }

--- a/lib/core/shared/dialogs/email_verification_dialog.dart
+++ b/lib/core/shared/dialogs/email_verification_dialog.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:streamfi/core/constants/app_texts.dart';
+import 'package:streamfi/core/themes/color_scheme.dart';
+
+class EmailVerificationDialog extends StatefulWidget {
+  final String email;
+  final Function(String) onVerify;
+  final VoidCallback onResend;
+
+  const EmailVerificationDialog({
+    Key? key,
+    required this.email,
+    required this.onVerify,
+    required this.onResend,
+  }) : super(key: key);
+
+  @override
+  State<EmailVerificationDialog> createState() => _EmailVerificationDialogState();
+}
+
+class _EmailVerificationDialogState extends State<EmailVerificationDialog> {
+  final List<TextEditingController> controllers = List.generate(
+    6,
+    (index) => TextEditingController(),
+  );
+
+  final List<FocusNode> focusNodes = List.generate(
+    6,
+    (index) => FocusNode(),
+  );
+
+  @override
+  void dispose() {
+    for (var controller in controllers) {
+      controller.dispose();
+    }
+    for (var node in focusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isTablet = MediaQuery.of(context).size.width > 600;
+    
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: EdgeInsets.symmetric(horizontal: isTablet ? 0 : 16.w),
+      child: Container(
+        width: isTablet ? 406 : 293.w,
+        decoration: BoxDecoration(
+          color: AppColors.dialogBackground,
+          borderRadius: BorderRadius.circular(isTablet ? 24 : 24.r),
+        ),
+        padding: EdgeInsets.all(isTablet ? 24 : 20.r),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Title
+            Text(
+              isTablet ? AppTexts.verificationTitle : AppTexts.verificationTitleMobile,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: AppColors.white,
+                fontSize: isTablet ? 24 : 24.sp,
+                fontWeight: FontWeight.w600,
+                height: 1.2,
+              ),
+            ),
+            SizedBox(height: isTablet ? 24 : 10.h),
+            
+            // Instruction text
+            RichText(
+              textAlign: TextAlign.center,
+              text: TextSpan(
+                style: TextStyle(
+                  color: AppColors.instructionTextGrey,
+                  fontSize: isTablet ? 16 : 16.sp,
+                  fontFamily: 'Inter',
+                  fontWeight: FontWeight.w400,
+                  height: 1.5,
+                  letterSpacing: 0,
+                ),
+                children: [
+                  TextSpan(text: AppTexts.verificationInstruction),
+                  TextSpan(
+                    text: widget.email,
+                    style: TextStyle(
+                      color: AppColors.white,
+                      fontWeight: FontWeight.w600,
+                      fontFamily: 'Inter',
+                      fontSize: isTablet ? 16 : 16.sp,
+                    ),
+                  ),
+                  TextSpan(text: AppTexts.verificationValidity),
+                ],
+              ),
+            ),
+            SizedBox(height: isTablet ? 24 : 32.h),
+            
+            // Pin Fields Row
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: isTablet ? 8 : 8.w),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: List.generate(
+                  6,
+                  (index) => _buildPinField(index),
+                ),
+              ),
+            ),
+            SizedBox(height: isTablet ? 24 : 40.h),
+            
+            // Verify button
+            SizedBox(
+              width: double.infinity,
+              height: isTablet ? 50 : 50.h,
+              child: ElevatedButton(
+                onPressed: _verifyCode,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.verifyButtonPurple,
+                  foregroundColor: AppColors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(isTablet ? 8 : 8.r),
+                  ),
+                  elevation: 0,
+                ),
+                child: Text(
+                  AppTexts.verifyButton,
+                  style: TextStyle(
+                    fontSize: isTablet ? 16 : 16.sp,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(height: isTablet ? 24 : 16.h),
+            
+            // Resend code text
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  AppTexts.resendText,
+                  style: TextStyle(
+                    color: AppColors.instructionTextGrey,
+                    fontSize: isTablet ? 14 : 14.sp,
+                  ),
+                ),
+                GestureDetector(
+                  onTap: widget.onResend,
+                  child: Text(
+                    AppTexts.resendButton,
+                    style: TextStyle(
+                      color: AppColors.white,
+                      fontSize: isTablet ? 14 : 14.sp,
+                      fontWeight: FontWeight.w600,
+                      decoration: TextDecoration.underline,
+                      decorationColor: AppColors.white,
+                      decorationThickness: 1.5,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPinField(int index) {
+    final isTablet = MediaQuery.of(context).size.width > 600;
+    
+    return Container(
+      width: isTablet ? 40 : 32.w,
+      height: isTablet ? 40 : 32.w,
+      decoration: BoxDecoration(
+        color: AppColors.pinBoxBackground,
+        borderRadius: BorderRadius.circular(isTablet ? 8 : 8.r),
+        border: Border.all(
+          color: focusNodes[index].hasFocus 
+              ? AppColors.pinBoxBorderPurple
+              : Colors.transparent,
+          width: isTablet ? 1 : 1.w,
+        ),
+      ),
+      child: Center(
+        child: Focus(
+          onFocusChange: (hasFocus) {
+            setState(() {});
+          },
+          child: TextField(
+            controller: controllers[index],
+            focusNode: focusNodes[index],
+            onChanged: (value) {
+              if (value.isNotEmpty) {
+                if (index < 5) {
+                  focusNodes[index + 1].requestFocus();
+                } else {
+                  focusNodes[index].unfocus();
+                  _verifyCode();
+                }
+              }
+            },
+            showCursor: false,
+            textAlign: TextAlign.center,
+            keyboardType: TextInputType.number,
+            inputFormatters: [
+              LengthLimitingTextInputFormatter(1),
+              FilteringTextInputFormatter.digitsOnly,
+            ],
+            decoration: InputDecoration(
+              border: InputBorder.none,
+              contentPadding: EdgeInsets.zero,
+              isDense: true,
+              hintText: focusNodes[index].hasFocus ? '-' : '',
+              hintStyle: TextStyle(
+                color: AppColors.white,
+                fontSize: isTablet ? 16 : 16.sp,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            style: TextStyle(
+              color: AppColors.white,
+              fontSize: isTablet ? 16 : 16.sp,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _verifyCode() {
+    final code = controllers.map((controller) => controller.text).join();
+    if (code.length == 6) {
+      widget.onVerify(code);
+    }
+  }
+} 

--- a/lib/core/themes/color_scheme.dart
+++ b/lib/core/themes/color_scheme.dart
@@ -37,4 +37,11 @@ class AppColors {
   static const Color white250 = Color(0xFFFAFAFA);
   static const Color gradientColor = Color(0xFFEDEAFF);
   static const Color white = Colors.white;
+
+  // Verification Dialog Colors
+  static const Color dialogBackground = Color.fromRGBO(28, 28, 28, 1);
+  static const Color pinBoxBackground = Color.fromRGBO(0, 0, 0, 0.25);
+  static const Color verifyButtonPurple = Color.fromRGBO(90, 24, 154, 1);
+  static const Color pinBoxBorderPurple = Color.fromRGBO(90, 24, 154, 1);
+  static const Color instructionTextGrey = Color(0xFF9E9E9E);
 }


### PR DESCRIPTION
This PR implements the email verification UI that supports both mobile and tablet devices.

Changes:
- Add EmailVerificationDialog component with responsive design
- Add verification-related color constants
- Add verification-related text constants
- Support both mobile and tablet layouts
- Implement 6-digit code input with auto-focus
- Add verify and resend functionality

The implementation follows the design from Figma and includes:
- Responsive layout for both mobile (<600px) and tablet (≥600px)
- Proper styling and color constants
- Text constants for maintainability
- Auto-focus behavior for PIN input
- Verify and resend code functionality


<img width="366" alt="mobile" src="https://github.com/user-attachments/assets/c947d934-2761-4e16-8769-6922e3e69f56" />
<img width="366" alt="mobile2" src="https://github.com/user-attachments/assets/a9dd1af2-130a-491c-9bf8-b00a3b902a2e" />

<img width="533" alt="IpadUi" src="https://github.com/user-attachments/assets/f6c7c8f6-8788-424f-884a-e71be522a6db" />

Mobile:
- Width: 293.w
- Padding: 20.r
- Pin boxes: 32.w x 32.w
- Two-line title

Tablet:
- Width: 406px
- Padding: 24px
- Pin boxes: 40x40px
- Single-line title
- Consistent 24px gaps

Closes #8